### PR TITLE
Упрощена инъекция IWebClient

### DIFF
--- a/Morpher.WebService.V3.Client.UnitTests/MockClientHelpers.cs
+++ b/Morpher.WebService.V3.Client.UnitTests/MockClientHelpers.cs
@@ -34,12 +34,7 @@
 
         public static MorpherClient NewMorpherClientInject(IWebClient webClient)
         {
-            var morpherClient = new MorpherClient();
-            morpherClient.NewClient = () => new MyWebClient(morpherClient.Token, morpherClient.Url)
-            {
-                WebClient = webClient
-            };
-            return morpherClient;
+            return new MorpherClient(null, null, webClient);
         }
     }
 }

--- a/Morpher.WebService.V3.Client.UnitTests/Russian.cs
+++ b/Morpher.WebService.V3.Client.UnitTests/Russian.cs
@@ -114,11 +114,7 @@
             var webClient = new Mock<IWebClient>();
             webClient.Setup(client => client.QueryString).Returns(new NameValueCollection());
             webClient.Setup(client => client.DownloadString(It.IsAny<string>())).Returns(DeclensionResultText);
-            var morpherClient = new MorpherClient();
-            morpherClient.NewClient = () => new MyWebClient(morpherClient.Token, morpherClient.Url)
-            {
-                WebClient = webClient.Object
-            };
+            var morpherClient = new MorpherClient(null, null, webClient.Object);
 
             DeclensionResult declensionResult = morpherClient.Russian.Parse("тест");
             Assert.IsNotNull(declensionResult);
@@ -152,11 +148,7 @@
             var webClient = new Mock<IWebClient>();
             webClient.Setup(client => client.QueryString).Returns(new NameValueCollection());
             webClient.Setup(client => client.DownloadString(It.IsAny<string>())).Returns(FioSplit);
-            var morpherClient = new MorpherClient();
-            morpherClient.NewClient = () => new MyWebClient(morpherClient.Token, morpherClient.Url)
-            {
-                WebClient = webClient.Object
-            };
+            var morpherClient = new MorpherClient(null, null, webClient.Object);
 
             DeclensionResult declensionResult = morpherClient.Russian.Parse("Александр Пушкин Сергеевич");
             Assert.IsNotNull(declensionResult);
@@ -172,11 +164,7 @@
             var webClient = new Mock<IWebClient>();
             webClient.Setup(client => client.QueryString).Returns(new NameValueCollection());
             webClient.Setup(client => client.DownloadString(It.IsAny<string>())).Returns(SpellResultText);
-            var morpherClient = new MorpherClient();
-            morpherClient.NewClient = () => new MyWebClient(morpherClient.Token, morpherClient.Url)
-            {
-                WebClient = webClient.Object
-            };
+            var morpherClient = new MorpherClient(null, null, webClient.Object);
 
             NumberSpellingResult declensionResult = morpherClient.Russian.Spell(10, "рубль");
             Assert.IsNotNull(declensionResult);
@@ -205,11 +193,7 @@
             var webClient = new Mock<IWebClient>();
             webClient.Setup(client => client.QueryString).Returns(new NameValueCollection());
             webClient.Setup(client => client.DownloadString(It.IsAny<string>())).Returns(GendersResultText);
-            var morpherClient = new MorpherClient();
-            morpherClient.NewClient = () => new MyWebClient(morpherClient.Token, morpherClient.Url)
-            {
-                WebClient = webClient.Object
-            };
+            var morpherClient = new MorpherClient(null, null, webClient.Object);
 
             AdjectiveGenders adjectiveGenders = morpherClient.Russian.AdjectiveGenders("уважаемый");
             Assert.IsNotNull(adjectiveGenders);
@@ -225,11 +209,7 @@
             var webClient = new Mock<IWebClient>();
             webClient.Setup(client => client.QueryString).Returns(new NameValueCollection());
             webClient.Setup(client => client.DownloadString(It.IsAny<string>())).Returns(AdjectivizeResultText);
-            var morpherClient = new MorpherClient();
-            morpherClient.NewClient = () => new MyWebClient(morpherClient.Token, morpherClient.Url)
-            {
-                WebClient = webClient.Object
-            };
+            var morpherClient = new MorpherClient(null, null, webClient.Object);
 
             List<string> adjList = morpherClient.Russian.Adjectivize("мытыщи");
             Assert.IsNotNull(adjList);
@@ -273,11 +253,7 @@
             webClient.Setup(client => client.QueryString).Returns(@params);
             webClient.Setup(client => client.UploadValues(It.IsAny<string>(), "DELETE", It.IsAny<NameValueCollection>()))
                 .Returns(Encoding.UTF8.GetBytes("true"));
-            var morpherClient = new MorpherClient();
-            morpherClient.NewClient = () => new MyWebClient(morpherClient.Token, morpherClient.Url)
-            {
-                WebClient = webClient.Object
-            };
+            var morpherClient = new MorpherClient(null, null, webClient.Object);
 
             bool found = morpherClient.Russian.UserDict.Remove("кошка");
 
@@ -297,11 +273,7 @@
             webClient.Setup(
                     client => client.UploadValues(It.IsAny<string>(), "DELETE", It.IsAny<NameValueCollection>()))
                 .Throws(exception);
-            var morpherClient = new MorpherClient();
-            morpherClient.NewClient = () => new MyWebClient(morpherClient.Token, morpherClient.Url)
-            {
-                WebClient = webClient.Object
-            };
+            var morpherClient = new MorpherClient(null, null, webClient.Object);
 
             Assert.Throws<ArgumentEmptyException>(() => morpherClient.Russian.UserDict.Remove("exception here"));
         }
@@ -312,11 +284,7 @@
             var webClient = new Mock<IWebClient>();
             webClient.Setup(client => client.QueryString).Returns(new NameValueCollection());
             webClient.Setup(client => client.DownloadString(It.IsAny<string>())).Returns(UserDictGetAllText);
-            var morpherClient = new MorpherClient();
-            morpherClient.NewClient = () => new MyWebClient(morpherClient.Token, morpherClient.Url)
-            {
-                WebClient = webClient.Object
-            };
+            var morpherClient = new MorpherClient(null, null, webClient.Object);
 
             IEnumerable<CorrectionEntry> correctionEntries = morpherClient.Russian.UserDict.GetAll()?.ToList();
 

--- a/Morpher.WebService.V3.Client.UnitTests/Ukrainian.cs
+++ b/Morpher.WebService.V3.Client.UnitTests/Ukrainian.cs
@@ -70,11 +70,7 @@ namespace Morpher.WebService.V3.Client.UnitTests
             var webClient = new Mock<IWebClient>();
             webClient.Setup(client => client.QueryString).Returns(new NameValueCollection());
             webClient.Setup(client => client.DownloadString(It.IsAny<string>())).Returns(DeclensionResultText);
-            var morpherClient = new MorpherClient();
-            morpherClient.NewClient = () => new MyWebClient(morpherClient.Token, morpherClient.Url)
-            {
-                WebClient = webClient.Object
-            };
+            var morpherClient = new MorpherClient(null, null, webClient.Object);
 
             DeclensionResult declensionResult = morpherClient.Ukrainian.Parse("тест");
             Assert.IsNotNull(declensionResult);
@@ -94,11 +90,7 @@ namespace Morpher.WebService.V3.Client.UnitTests
             var webClient = new Mock<IWebClient>();
             webClient.Setup(client => client.QueryString).Returns(new NameValueCollection());
             webClient.Setup(client => client.DownloadString(It.IsAny<string>())).Returns(SpellText);
-            var morpherClient = new MorpherClient();
-            morpherClient.NewClient = () => new MyWebClient(morpherClient.Token, morpherClient.Url)
-            {
-                WebClient = webClient.Object
-            };
+            var morpherClient = new MorpherClient(null, null, webClient.Object);
 
             NumberSpellingResult declensionResult = morpherClient.Ukrainian.Spell(10, "рубль");
             Assert.IsNotNull(declensionResult);
@@ -132,11 +124,7 @@ namespace Morpher.WebService.V3.Client.UnitTests
                 WebResponseMock.CreateWebResponse((HttpStatusCode)495,
                     new MemoryStream(Encoding.UTF8.GetBytes(ExceptionText.UseSpell))));
             webClient.Setup(client => client.DownloadString(It.IsAny<string>())).Throws(exception);
-            var morpherClient = new MorpherClient();
-            morpherClient.NewClient = () => new MyWebClient(morpherClient.Token, morpherClient.Url)
-            {
-                WebClient = webClient.Object
-            };
+            var morpherClient = new MorpherClient(null, null, webClient.Object);
 
             Assert.Throws<NumeralsDeclensionNotSupportedException>(() => morpherClient.Ukrainian.Parse("exception here"));
         }
@@ -150,11 +138,7 @@ namespace Morpher.WebService.V3.Client.UnitTests
                 WebResponseMock.CreateWebResponse((HttpStatusCode)400,
                     new MemoryStream(Encoding.UTF8.GetBytes(ExceptionText.MissedParameter))));
             webClient.Setup(client => client.DownloadString(It.IsAny<string>())).Throws(exception);
-            var morpherClient = new MorpherClient();
-            morpherClient.NewClient = () => new MyWebClient(morpherClient.Token, morpherClient.Url)
-            {
-                WebClient = webClient.Object
-            };
+            var morpherClient = new MorpherClient(null, null, webClient.Object);
 
             Assert.Throws<ArgumentEmptyException>(() => morpherClient.Ukrainian.Parse("exception here"));
         }
@@ -167,11 +151,7 @@ namespace Morpher.WebService.V3.Client.UnitTests
             webClient.Setup(client => client.QueryString).Returns(@params);
             webClient.Setup(client => client.UploadValues(It.IsAny<string>(), "DELETE", It.IsAny<NameValueCollection>()))
                 .Returns(Encoding.UTF8.GetBytes("true"));
-            var morpherClient = new MorpherClient();
-            morpherClient.NewClient = () => new MyWebClient(morpherClient.Token, morpherClient.Url)
-            {
-                WebClient = webClient.Object
-            };
+            var morpherClient = new MorpherClient(null, null, webClient.Object);
 
             bool found = morpherClient.Ukrainian.UserDict.Remove("тест");
 
@@ -185,11 +165,7 @@ namespace Morpher.WebService.V3.Client.UnitTests
             var webClient = new Mock<IWebClient>();
             webClient.Setup(client => client.QueryString).Returns(new NameValueCollection());
             webClient.Setup(client => client.DownloadString(It.IsAny<string>())).Returns(UserDictGetAllText);
-            var morpherClient = new MorpherClient();
-            morpherClient.NewClient = () => new MyWebClient(morpherClient.Token, morpherClient.Url)
-            {
-                WebClient = webClient.Object
-            };
+            var morpherClient = new MorpherClient(null, null, webClient.Object);
 
             IEnumerable<CorrectionEntry> correctionEntries = morpherClient.Ukrainian.UserDict.GetAll().ToList();
 

--- a/Morpher.WebService.V3.Client/MorpherClient.cs
+++ b/Morpher.WebService.V3.Client/MorpherClient.cs
@@ -4,31 +4,29 @@
 
     public class MorpherClient
     {
-        private Func<MyWebClient> _newClient;
+        private readonly IWebClient _webClient;
 
-        private Russian.Client _russian;
-
-        private Ukrainian.Client _ukrainian;
-
-        public MorpherClient(Guid? token = null, string url = null)
+        public MorpherClient(Guid? token = null, string url = null, IWebClient webClient = null)
         {
+            _webClient = webClient;
             this.Token = token;
             this.Url = url ?? "http://ws3.morpher.ru";
+            Russian = new Russian.Client(NewClient);
+            Ukrainian = new Ukrainian.Client(NewClient);
         }
 
-        public Func<MyWebClient> NewClient
+        MyWebClient NewClient()
         {
-            get => _newClient ?? (_newClient = () => new MyWebClient(Token, Url));
-            set => _newClient = value ?? throw new ArgumentNullException(nameof(value));
+            return new MyWebClient(Token, Url, _webClient);
         }
 
-        public Russian.Client Russian => _russian ?? (_russian = new Russian.Client(NewClient));
+        public Russian.Client Russian { get; }
 
-        public Ukrainian.Client Ukrainian => _ukrainian ?? (_ukrainian = new Ukrainian.Client(NewClient));
+        public Ukrainian.Client Ukrainian { get; }
 
-        public string Url { get; }
+        string Url { get; }
 
-        public Guid? Token { get; }
+        Guid? Token { get; }
 
         public int QueriesLeftForToday(Guid? guid = null)
         {

--- a/Morpher.WebService.V3.Client/MyWebClient.cs
+++ b/Morpher.WebService.V3.Client/MyWebClient.cs
@@ -8,39 +8,33 @@ namespace Morpher.WebService.V3
     using System.Collections.Specialized;
     using Newtonsoft.Json;
 
-    public class MyWebClient : IDisposable
+    internal class MyWebClient : IDisposable
     {
         readonly string _baseUrl;
-        IWebClient _webClient;
+        readonly IWebClient _webClient;
 
-        public MyWebClient(Guid? token, string baseUrl)
+        public MyWebClient(Guid? token, string baseUrl, IWebClient webClient = null)
         {
             _baseUrl = baseUrl;
+            _webClient = webClient ?? new MorpherWebClient { Encoding = Encoding.UTF8 };
             if (token != null)
             {
                 AddParam("token", token.ToString());
             }
 
             AddParam("format", "json");
-
-        }
-
-        public IWebClient WebClient
-        {
-            get => _webClient ?? (_webClient = new MorpherWebClient {Encoding = Encoding.UTF8});
-            set => _webClient = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         public void AddParam(string name, string value)
         {
-            WebClient.QueryString.Add(name, value);
+            _webClient.QueryString.Add(name, value);
         }
 
         public T GetObject<T>(string relativeUrl)
         {
             try
             {
-                string response = WebClient.DownloadString(_baseUrl + relativeUrl);
+                string response = _webClient.DownloadString(_baseUrl + relativeUrl);
                 return Deserialize<T>(response);
             }
             catch (WebException exc)
@@ -54,7 +48,7 @@ namespace Morpher.WebService.V3
         {
             try
             {
-                WebClient.UploadValues(_baseUrl + relativeUrl, collection);
+                _webClient.UploadValues(_baseUrl + relativeUrl, collection);
             }
             catch (WebException exc)
             {
@@ -65,14 +59,14 @@ namespace Morpher.WebService.V3
 
         public void AddHeader(HttpRequestHeader header, string value)
         {
-            WebClient.Headers.Add(header, value);
+            _webClient.Headers.Add(header, value);
         }
 
         public T UploadString<T>(string relativeUrl, string data)
         {
             try
             {
-                string response = WebClient.UploadString(_baseUrl + relativeUrl, data);
+                string response = _webClient.UploadString(_baseUrl + relativeUrl, data);
                 
                 return Deserialize<T>(response);
             }
@@ -87,7 +81,7 @@ namespace Morpher.WebService.V3
         {
             try
             {
-                byte[] response = WebClient.UploadValues(_baseUrl + relativeUrl, "DELETE", new NameValueCollection());
+                byte[] response = _webClient.UploadValues(_baseUrl + relativeUrl, "DELETE", new NameValueCollection());
                 return Deserialize<T>(response);
             }
             catch (WebException exc)
@@ -147,7 +141,7 @@ namespace Morpher.WebService.V3
  
         public void Dispose()
         {
-            WebClient.Dispose();
+            _webClient.Dispose();
         }
     }
 }


### PR DESCRIPTION
Класс MorpherClient стал полностью readonly и, как следствие, thread-safe. Публичный API поменялся, так что в следующем релизе должна быть увеличена мажорная версия.